### PR TITLE
TRITON-2173 ufds build broken due to node module ipaddr.js changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ufds",
-    "version": "7.3.0",
+    "version": "7.3.1",
     "repository": {
         "type": "git",
         "url": "git@github.com:joyent/sdc-ufds.git"
@@ -21,7 +21,7 @@
         "bunyan": "0.22.1",
         "crc": "0.2.0",
         "ldapjs": "git+https://github.com/mcavage/node-ldapjs.git#0509dd44c0eb6dad7235df7838bdb05ea31cde14",
-        "moray": "git+https://github.com/joyent/node-moray.git#fd5781bc25a9bfe2ba82167664639753fb9f0ca5",
+        "moray": "git+https://github.com/joyent/node-moray.git#debd4617e6810241f51d9256470e7383ab4c2ffd",
         "nopt": "2.1.1",
         "once": "1.3.0",
         "restify": "2.3.4",


### PR DESCRIPTION
Here is the node-moray commit change:
https://github.com/joyent/node-moray/commit/debd4617e6810241f51d9256470e7383ab4c2ffd
which now results in ipaddr.js version 0.1.9 being installed (instead of the 2.0.0 version).

Tested in nightly-4 by installing the updated build of sdc-ufds and running some triton cli actions against the nightly-4 DC. All working.